### PR TITLE
Handles temp files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,8 @@ mod server;
 mod markdown;
 
 use notify::{RecommendedWatcher, RecursiveMode, Watcher, Config};
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::process;
 use std::env;
 use std::net::TcpListener;
@@ -21,7 +22,7 @@ fn port_is_available(port: u16) -> bool {
     }
 }
 
-fn watch(path_dir: &std::path::Path, path_file: &String, port: u16) -> notify::Result<()> {
+fn watch(path_dir: &std::path::Path, path_file: &String, temp_dir: &std::path::Path, port: u16) -> notify::Result<()> {
     let (tx, rx) = std::sync::mpsc::channel();
 
     let mut watcher = RecommendedWatcher::new(tx, Config::default())?;
@@ -34,7 +35,7 @@ fn watch(path_dir: &std::path::Path, path_file: &String, port: u16) -> notify::R
                 if event.paths.len() > 0 {
                     let teststr = format!("{}", event.paths[0].display());
                     if teststr.contains(path_file) {
-                        markdown::to_html(&path_dir, &path_file, port);
+                        markdown::to_html(&path_file, temp_dir, port);
                     }
                 }
             },
@@ -70,33 +71,35 @@ fn main() {
 
     let s_slice2 = string_to_static_str(path_dir_for_server.to_str().unwrap().to_string());
 
-    let path_parsed0 = Path::new(s_slice);
-    let path_dir_for_initial_md = path_parsed0.parent().unwrap();
-
     if args.len() < 2 {
         println!("ERROR: Required arguments. \"file\"\n");
         println!("Please see the `--help`.");
         process::exit(1);
     }
 
+    let temp_dir: PathBuf = env::temp_dir().join(format!("mip-{}", process::id()));
+    fs::create_dir_all(&temp_dir).expect("Unable to create temp directory");
+    let temp_dir_str = string_to_static_str(temp_dir.to_str().unwrap().to_string());
+    let temp_dir_for_watcher = temp_dir.clone();
+
     if let Some(available_port) = get_available_port() {
-        markdown::to_html(&path_dir_for_initial_md, &path_file, available_port);
+        markdown::to_html(&path_file, &temp_dir, available_port);
 
         let tr = tokio::runtime::Runtime::new().unwrap();
         tr.spawn(async move{
             let path_parsed = Path::new(&path_file);
             let path_dir_for_watcher = path_parsed.parent().unwrap();
 
-            if let Err(e) = watch(path_dir_for_watcher, &path_file, available_port) {
+            if let Err(e) = watch(path_dir_for_watcher, &path_file, &temp_dir_for_watcher, available_port) {
                 println!("error: {:?}", e)
             }
         });
 
         tr.spawn(async move{
-            RestBro::run_bro(s_slice2, available_port).await;
+            RestBro::run_bro(s_slice2, temp_dir_str, available_port).await;
         });
 
-        let _view_res = view::window(available_port);
+        let _view_res = view::window(available_port, temp_dir);
     }
     else{
         panic!("E2");

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -9,16 +9,16 @@ use pulldown_cmark::{html, Options, Parser};
 #[folder = "asset/theme1"]
 struct Asset;
 
-pub fn to_html(path_dir: &std::path::Path, infile: &String, port: u16 ){
+pub fn to_html(infile: &String, output_dir: &std::path::Path, port: u16 ){
 
     let markdown_input = fs::read_to_string(infile);
     match markdown_input {
-        Ok(markdown_input) => to_file(path_dir, &markdown_input, port),
+        Ok(markdown_input) => to_file(&markdown_input, output_dir, port),
         Err(_) => {}
     };
 }
 
-fn to_file(path_dir: &std::path::Path, markdown_input: &String, port: u16 ){
+fn to_file(markdown_input: &String, output_dir: &std::path::Path, port: u16 ){
     let seed_url = format!("http://localhost:{}/.temp.seed", port);
 
     let matter = Matter::<YAML>::new();
@@ -47,8 +47,8 @@ fn to_file(path_dir: &std::path::Path, markdown_input: &String, port: u16 ){
             let html_complete1 = index_html_str.replace("#{BODY}", &html_output);
             let html_complete2 = html_complete1.replace("#{INITIALSEED}", &seed);
             let html_complete3 = html_complete2.replace("#{SEEDURL}", &seed_url);
-            fs::write(path_dir.join(".temp.seed"), seed).expect("Unable to write file");
-            fs::write(path_dir.join(".temp.html"), html_complete3).expect("Unable to write file");
+            fs::write(output_dir.join(".temp.seed"), seed).expect("Unable to write file");
+            fs::write(output_dir.join(".temp.html"), html_complete3).expect("Unable to write file");
         },
         Err(_) => println!("URF this..no file")
     };

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,11 +1,20 @@
+use warp::Filter;
+
 pub struct RestBro;
 
 impl RestBro {
 
-    pub async fn run_bro(path_dir: &'static str, port: u16) {
+    pub async fn run_bro(path_dir: &'static str, temp_dir: &'static str, port: u16) {
 
         println!("{}", path_dir);
-        warp::serve(warp::fs::dir(path_dir))
+
+        let temp_html = warp::path(".temp.html")
+            .and(warp::fs::file(format!("{}/.temp.html", temp_dir)));
+        let temp_seed = warp::path(".temp.seed")
+            .and(warp::fs::file(format!("{}/.temp.seed", temp_dir)));
+        let assets = warp::fs::dir(path_dir);
+
+        warp::serve(temp_html.or(temp_seed).or(assets))
             .run(([127, 0, 0, 1], port))
             .await;
     }

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use tao::{
   event::{Event, WindowEvent},
   event_loop::{ControlFlow, EventLoop},
@@ -5,7 +7,7 @@ use tao::{
 };
 use wry::WebViewBuilder;
 
-pub fn window(port: u16) -> wry::Result<()> {
+pub fn window(port: u16, temp_dir: PathBuf) -> wry::Result<()> {
   let event_loop = EventLoop::new();
   let window = WindowBuilder::new()
     .with_title("MiP")
@@ -59,6 +61,7 @@ pub fn window(port: u16) -> wry::Result<()> {
       ..
     } = event
     {
+      let _ = std::fs::remove_dir_all(&temp_dir);
       *control_flow = ControlFlow::Exit;
     }
   });


### PR DESCRIPTION
First of all, thanks for creating and maintaining `mip` :pink_heart: 

This PR suggests these two tiny (and related) changes:

- Writes `.temp.seed` and `.temp.html` to `$TMPDIR/mip-{pid}` instead of next to the markdown source, and removes the directory on window close (see #2).
- Serves the temp files from there while still serving relative assets (images, etc.) from the markdown's directory.